### PR TITLE
Document supported use of ISO8601 with DATEFORMAT 'auto'

### DIFF
--- a/doc_source/automatic-recognition.md
+++ b/doc_source/automatic-recognition.md
@@ -3,12 +3,25 @@
 If you specify `'auto'` as the argument for the DATEFORMAT or TIMEFORMAT parameter, Amazon Redshift will automatically recognize and convert the date format or time format in your source data\. The following shows an example\.
 
 ```
-copy favoritemovies from 'dynamodb://ProductCatalog' 
+copy favoritemovies from 'dynamodb://ProductCatalog'
 iam_role 'arn:aws:iam::0123456789012:role/MyRedshiftRole'
 dateformat 'auto';
 ```
 
 When used with the `'auto'` argument for DATEFORMAT and TIMEFORMAT, COPY recognizes and converts the date and time formats listed in the table in [ DATEFORMAT and TIMEFORMAT Strings](r_DATEFORMAT_and_TIMEFORMAT_strings.md)\. In addition, the `'auto'` argument recognizes the following formats that are not supported when using a DATEFORMAT and TIMEFORMAT string\.
+
+| Format                    | Example of Valid Input String |
+| ------------------------- | ----------------------------- |
+| Julian                    | J2451187                      |
+| BC                        | Jan-08-95 BC                  |
+| YYYYMMDD HHMISS           | 19960108 040809               |
+| YYMMDD HHMISS             | 960108 040809                 |
+| YYYY.DDD                  | 1996.008                      |
+| YYYY-MM-DD HH:MI:SS.SSS   | 1996-01-08 04:05:06.789       |
+| DD Mon HH:MI:SS YYYY TZ   | 17 Dec 07:37:16 1997 PST      |
+| MM/DD/YYYY HH:MI:SS.SS TZ | 12/17/1997 07:37:16.00 PST    |
+| YYYY-MM-DD HH:MI:SS+/-TZ  | 1997-12-17 07:37:16-08        |
+| DD.MM.YYYY HH:MI:SS TZ    | 12.17.1997 07:37:16.00 PST    |
 
 Automatic recognition does not support epochsecs and epochmillisecs\.
 

--- a/doc_source/automatic-recognition.md
+++ b/doc_source/automatic-recognition.md
@@ -10,8 +10,6 @@ dateformat 'auto';
 
 When used with the `'auto'` argument for DATEFORMAT and TIMEFORMAT, COPY recognizes and converts the date and time formats listed in the table in [ DATEFORMAT and TIMEFORMAT Strings](r_DATEFORMAT_and_TIMEFORMAT_strings.md)\. In addition, the `'auto'` argument recognizes the following formats that are not supported when using a DATEFORMAT and TIMEFORMAT string\.
 
-[\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/redshift/latest/dg/automatic-recognition.html)
-
 Automatic recognition does not support epochsecs and epochmillisecs\.
 
 To test whether a date or timestamp value will be automatically converted, use a CAST function to attempt to convert the string to a date or timestamp value\. For example, the following commands test the timestamp value `'J2345678 04:05:06.789'`:

--- a/doc_source/automatic-recognition.md
+++ b/doc_source/automatic-recognition.md
@@ -12,6 +12,7 @@ When used with the `'auto'` argument for DATEFORMAT and TIMEFORMAT, COPY recogni
 
 | Format                    | Example of Valid Input String |
 | ------------------------- | ----------------------------- |
+| ISO 8601                  | 2019-02-11T05:09:12.195Z      |
 | Julian                    | J2451187                      |
 | BC                        | Jan-08-95 BC                  |
 | YYYYMMDD HHMISS           | 19960108 040809               |


### PR DESCRIPTION
*Description of changes:*
This explicitly documents that ISO 8601 is a supported format with `DATEFORMAT 'auto'`. This format is commonly used with JSON, and without this information, it would appear that it is not possible to use the `COPY` with JSON files which include dates.

I also removed a link which I felt did not add useful information; it was a link referring back to to this same documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
