### PR TITLE
Fix docs in merge-specify-a-column-list guide

### DIFF
--- a/doc_source/merge-specify-a-column-list.md
+++ b/doc_source/merge-specify-a-column-list.md
@@ -53,11 +53,11 @@
    where stage.primarykey = target.primarykey;
    ```
 
-1. Insert the remaining rows from the staging table\. Use the same column list in the VALUES clause that you used in the UPDATE statement in step two\. 
+1. Insert the remaining rows from the staging table\. Use the same column list in the VALUES clause that you used in the UPDATE statement in step three\. 
 
    ```
    insert into target
-   (select col1, col2, 'expression')
+   select col1, col2, 'expression'
    from stage;
    
    end transaction;


### PR DESCRIPTION
*Issue #, if available:*

In step 5 there is a reference to columns in step 2 but actually it is step 3.
In step 5 there are parens around the select statement that led to an error.

*Description of changes:*

Fix docs and remove wrong parens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
