### PR TITLE
Added missing closing curly brackets

### DIFF
--- a/doc_source/r_TIMEZONE.md
+++ b/doc_source/r_TIMEZONE.md
@@ -9,7 +9,7 @@ For information and examples about how to convert time zone, see [CONVERT\_TIMEZ
 ## Syntax<a name="r_TIMEZONE-syntax"></a>
 
 ```
-TIMEZONE ('timezone', { timestamp | timestamptz )
+TIMEZONE ('timezone', { timestamp | timestamptz } )
 ```
 
 ## Arguments<a name="r_TIMEZONE-arguments"></a>


### PR DESCRIPTION
Because line 12 has an option between  timestamp and timestamptz. There was a missing closing curly brackets

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
