### PR TITLE
Removed Key based Option as it is not Supported

### DIFF
--- a/doc_source/copy-usage_notes-copy-from-columnar.md
+++ b/doc_source/copy-usage_notes-copy-from-columnar.md
@@ -36,7 +36,6 @@ COPY supports columnar formatted data with the following restrictions:
   + [CREDENTIALS](copy-parameters-authorization.md#copy-credentials)
   + [STATUPDATE ](copy-parameters-data-load.md#copy-statupdate)
   + [MANIFEST](copy-parameters-data-source-s3.md#copy-manifest)
-  + [ACCESS\_KEY\_ID, SECRET\_ACCESS\_KEY, and SESSION\_TOKEN](copy-parameters-authorization.md#copy-access-key-id)
 + If COPY encounters an error while loading, the command fails\. ACCEPTANYDATE, ACCEPTINVCHARS, and MAXERROR aren't supported for columnar data types\.
 + Error messages are sent only to the SQL client\. Errors aren't logged in STL\_LOAD\_ERRORS\.
 + COPY inserts values into the target table's columns in the same order as the columns occur in the columnar data files\. The number of columns in the target table and the number of columns in the data file must match\.


### PR DESCRIPTION
The ACCESS_KEY, SECRET_ACCESS_KEY, and SESSION_TOKEN are not suported for copying columnar data. The following error is thrown when attempting to use PARQET format with COPY using key based credentials:

InternalError: COPY from this file format only accepts IAM_ROLE credentials.
DETAIL:  
  -----------------------------------------------
  error:  COPY from this file format only accepts IAM_ROLE credentials.
  code:      8001
  context:   
  query:     0
  location:  xen_copy.cpp:159
  process:   padbmaster [pid=2105]
  -----------------------------------------------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
