### PR TITLE
Update verifying-that-data-loaded-correctly.md

### DIFF
--- a/doc_source/verifying-that-data-loaded-correctly.md
+++ b/doc_source/verifying-that-data-loaded-correctly.md
@@ -9,7 +9,7 @@ select query, trim(filename) as filename, curtime, status
 from stl_load_commits
 where filename like '%tickit%' order by query;
 
- query |           btrim           |          curtime           | status
+ query |           filename        |          curtime           | status
 -------+---------------------------+----------------------------+--------
  22475 | tickit/allusers_pipe.txt  | 2013-02-08 20:58:23.274186 |      1
  22478 | tickit/venue_pipe.txt     | 2013-02-08 20:58:25.070604 |      1


### PR DESCRIPTION
Fix "filename" column heading

*Issue #, if available:*

*Description of changes:*

The column heading "btrim" was incorrect -- the SQL shown would generate "filename" as the heading for that particular column.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
