### PR TITLE
Update PG_GET_COLS.md

### DIFF
--- a/doc_source/PG_GET_COLS.md
+++ b/doc_source/PG_GET_COLS.md
@@ -15,7 +15,7 @@ The name of an Amazon Redshift table or view\.
 
 ## Return type<a name="PG_GET_COLS-return-type"></a>
 
-VARCHAR 
+RECORD
 
 ## Usage notes<a name="PG_GET_COLS-usage-notes"></a>
 


### PR DESCRIPTION
When we run "select pg_get_cols('sales_vw');"  the output type is RECORD, not VARCHAR as it is not possible to any string function to handle the output.
The output for the second query in the example seems to be VARCHAR:
select * from pg_get_cols('sales_vw') 
cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
