### PR TITLE
Remove recursive ctes as unsupported feature

### DIFF
--- a/doc_source/c_unsupported-postgresql-features.md
+++ b/doc_source/c_unsupported-postgresql-features.md
@@ -33,6 +33,5 @@ Do not assume that the semantics of elements that Amazon Redshift and PostgreSQL
 + Management of External Data \(SQL/MED\)
 + Table functions
 + VALUES list used as constant tables
-+ Recursive common table expressions
 + Sequences
 + Full text search


### PR DESCRIPTION
Per the `WITH` documentation, recursive cte's are supported: https://docs.aws.amazon.com/redshift/latest/dg/r_WITH_clause.html

*Issue #, if available:*

*Description of changes:*
Remove Recursive common table expressions as unsupported now that `WITH` supports it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
