### PR TITLE
clarify relationship between substring functions

### DIFF
--- a/doc_source/r_CHARINDEX.md
+++ b/doc_source/r_CHARINDEX.md
@@ -1,6 +1,8 @@
 # CHARINDEX function<a name="r_CHARINDEX"></a>
 
-Returns the location of the specified substring within a string\. Synonym of the STRPOS function\.
+Returns the location of the specified substring within a string\.
+
+Similar to the [POSITION](r_POSITION.md) and [STRPOS](r_STRPOS.md) functions\.
 
 ## Syntax<a name="r_CHARINDEX-synopsis"></a>
 
@@ -57,5 +59,3 @@ charindex | count
 5 |	629
 (1 row)
 ```
-
-See [STRPOS function](r_STRPOS.md) for details\. 

--- a/doc_source/r_POSITION.md
+++ b/doc_source/r_POSITION.md
@@ -2,7 +2,7 @@
 
 Returns the location of the specified substring within a string\.
 
-Synonym of the [STRPOS function](r_STRPOS.md) function\.
+Similar to the [STRPOS](r_STRPOS.md) and [CHARINDEX](r_CHARINDEX.md) functions\.
 
 ## Syntax<a name="position-synopsis"></a>
 

--- a/doc_source/r_STRPOS.md
+++ b/doc_source/r_STRPOS.md
@@ -1,8 +1,8 @@
 # STRPOS function<a name="r_STRPOS"></a>
 
-Returns the position of a substring within a specified string\. 
+Returns the position of a substring within a specified string\.
 
-Synonym of [CHARINDEX function](r_CHARINDEX.md) and [POSITION function](r_POSITION.md)\. 
+Similar to the [CHARINDEX](r_CHARINDEX.md) and [POSITION](r_POSITION.md) functions\.
 
 ## Syntax<a name="r_STRPOS-synopsis"></a>
 


### PR DESCRIPTION
*Description of changes:*

The three functions STRPOS, CHARINDEX, and POSITION
are for the same purpose (to get the index of a substring
in a string), but they are described as "synonyms"
currently in the docs, which they are not, in the sense that 
they do not have identical meanings (the argument structures for 
all three of them are different). The word "synonym" is confusing
because it implies that they are aliases of each other.

So here we say "similar", and also we take off the note
at the bottom of one of them saying to look to the other
one for "details". They all have pretty much the same
information and examples, so that's not really necessary 
or helpful. And their relationship is flagged at the top of 
the article anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
