### PR TITLE
Update time-zone-names.md

### DIFF
--- a/doc_source/time-zone-names.md
+++ b/doc_source/time-zone-names.md
@@ -447,7 +447,7 @@ Europe/Isle_of_Man
 Europe/Istanbul
 Europe/Jersey
 Europe/Kaliningrad
-Europe/Kiev
+Europe/Kyiv
 Europe/Lisbon
 Europe/Ljubljana
 Europe/London


### PR DESCRIPTION
The right pronunciation for Capital of Ukraine is Kyiv, not Kiev. Please be so kind to approve this changes

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
